### PR TITLE
Pass DGRAM socket as a parameter, not a block

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ By default, `SysLogger` will write to `$stdout`. To override, either pass a devi
 ```ruby
 require 'syslogger'
 
-log = SysLogger.new(&SysLogger::Creators::unix_dgram_socket("/path/to/datagram/socket"))
+log = SysLogger.new(SysLogger::Creators::unix_dgram_socket("/path/to/datagram/socket"))
 log.info("Hello\nWorld")
 ```

--- a/lib/syslogger/creators.rb
+++ b/lib/syslogger/creators.rb
@@ -4,7 +4,7 @@ require 'socket'
 module SysLogger
   module Creators
     def self.unix_dgram_socket(socket_path)
-      proc {
+      Proc.new {
         client = Socket.new(Socket::Constants::AF_LOCAL, Socket::Constants::SOCK_DGRAM, 0)
         client.connect(Socket.pack_sockaddr_un(socket_path))
         client
@@ -12,7 +12,7 @@ module SysLogger
     end
 
     def self.unix_stream_socket(socket_path)
-      proc {
+      Proc.new {
         UnixSocket.new(socket_path)
       }
     end

--- a/lib/syslogger/logger.rb
+++ b/lib/syslogger/logger.rb
@@ -4,11 +4,11 @@ module SysLogger
   class Logger < MonoLogger
     attr_reader :logdev, :default_formatter
 
-    def initialize(logdev = nil, shift_age = 0, shift_size = 1048576, &block)
-      if logdev.nil? && block_given?
-        super(SysLogger::IO.new(&block), shift_age, shift_size)
+    def initialize(logdev = nil, shift_age = 0, shift_size = 1048576)
+      if logdev.is_a?(Proc)
+        super(SysLogger::IO.new(logdev), shift_age, shift_size)
       elsif logdev.nil?
-        super($stdout, shift_age, shift_size)
+        super(STDOUT, shift_age, shift_size)
       else
         super(logdev, shift_age, shift_size)
       end

--- a/syslogger.gemspec
+++ b/syslogger.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |spec|
   spec.name          = "syslogger5424"
-  spec.version       = "0.4.0"
-  spec.date          = "2016-10-11"
+  spec.version       = "0.5.0"
+  spec.date          = "2016-10-12"
   spec.summary       = "Logging via syslog using RFC 5424 format"
   spec.authors       = ["EasyPost"]
   spec.email         = "support@easypost.com"


### PR DESCRIPTION
Current initializer limit the usage of Syslogger. If I want to prepare `logdev` outside of method where `Syslogger.new` called I have to use this `::SysLogger::IO.new(&::SysLogger::Creators::unix_dgram_socket(ENV["LOG_DGRAM_SYSLOG"]))`
