### PR TITLE
if no appname is specified, use $SYSLOG_APPNAME

### DIFF
--- a/lib/syslogger/formatter/rfc5424.rb
+++ b/lib/syslogger/formatter/rfc5424.rb
@@ -54,6 +54,7 @@ module SysLogger
         @msgid = format_field(msgid, 32)
         @procid = procid
         @procid = format_field(procid || Process.pid.to_s, 128)
+        appname = appname || ENV["SYSLOG_APPNAME"]
         @appname = format_field(appname, 48)
 
         self.facility = facility || :local7


### PR DESCRIPTION
This is kind of haxy but, um, we forgot to make any way to actually set appname through a `Syslogger`.

I can also just expose an `appname=` method if people prefer.
