### PR TITLE
fix multiline messages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+[*.rb]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.spec]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/lib/syslogger/logger.rb
+++ b/lib/syslogger/logger.rb
@@ -22,9 +22,9 @@ module SysLogger
       # server properly.
       # default to a serverity of info.
       msg.split(/\r?\n/).each { |line|
-          if line then
-              self.info(line)
-          end
+        if line then
+          self.info(line)
+        end
       }
     end
 

--- a/spec/syslogger/io_spec.rb
+++ b/spec/syslogger/io_spec.rb
@@ -16,6 +16,10 @@ describe SysLogger::IO do
       expect(io.string).to eq "foobar"
     end
 
+    it "handles array messages" do
+      subject.write(["foo", "bar"])
+      expect(io.string).to eq "foobar"
+    end
   end
 
   describe "unix_dgram_socket" do

--- a/spec/syslogger/logger_spec.rb
+++ b/spec/syslogger/logger_spec.rb
@@ -1,14 +1,31 @@
 describe SysLogger::Logger do
   let(:io) { StringIO.new }
+  let(:time_under_test) { Time.new(2019, 10, 28, 12, 26, 0, "-07:00") }
 
   subject { SysLogger::Logger.new(io) }
 
   its("logdev.dev")       { is_expected.to be io }
   its(:default_formatter) { is_expected.to be_a SysLogger::Formatter::RFC5424 }
 
+  before(:example) do
+    allow(Time).to receive(:now).and_return(time_under_test)
+    allow(Socket).to receive(:gethostname).and_return("testhostname")
+    allow(Process).to receive(:pid).and_return(1234)
+    allow_any_instance_of(SysLogger::Formatter::RFC5424).to receive(:gen_xgroup).and_return(98765)
+  end
+
   it "logs exceptions" do
     subject.error StandardError.new("foobar")
     expect(io.string).to match(
       /<187>1.* - #{Process.pid} - \[meta x-group=".*"\] foobar \(StandardError\)/)
+  end
+
+  it "sends multiline messages as an array" do
+    expect(io).to receive(:write).with([
+      "<190>1 2019-10-28T12:26:00.000000-07:00 testhostname - 1234 - [meta x-group=\"98765\" x-counter=\"1\"] foo\n",
+      "<190>1 2019-10-28T12:26:00.000000-07:00 testhostname - 1234 - [meta x-group=\"98765\" x-counter=\"2\"] bar\n",
+      "<190>1 2019-10-28T12:26:00.000000-07:00 testhostname - 1234 - [meta x-group=\"98765\" x-counter=\"3\"] baz\n"
+    ])
+    subject.info "foo\nbar\nbaz"
   end
 end


### PR DESCRIPTION
Fixes two bugs:

 - Multiline messages when using a DGRAM socket were sent a single message containing newlines. Bad!
 - x-counter was not incremented for multiline messages