### PR TITLE
make it easier to override appname or procid for syslogger

### DIFF
--- a/lib/syslogger/formatter/rfc5424.rb
+++ b/lib/syslogger/formatter/rfc5424.rb
@@ -1,7 +1,8 @@
 module SysLogger
   module Formatter
     class RFC5424 < ::Logger::Formatter
-      attr_reader :msgid, :procid, :appname
+      attr_reader :msgid
+      attr_accessor :procid, :appname
 
       Format = "<%s>1 %s %s %s %s %s %s %s\n"
 
@@ -53,8 +54,7 @@ module SysLogger
         @hostname = Socket.gethostname
         @msgid = format_field(msgid, 32)
         @procid = procid
-        @procid = format_field(procid || Process.pid.to_s, 128)
-        @appname = format_field(appname, 48)
+        @appname = appname
 
         self.facility = facility || :local7
       end
@@ -88,7 +88,7 @@ module SysLogger
           structured_data["meta"]["x-counter"] = @counter
           sd = format_sdata(structured_data)
           Format % [pri, datetime.strftime("%FT%T.%6N%:z"), @hostname,
-                    @appname, format_field(@procid || Process.pid.to_s, 128),
+                    format_field(@appname, 48), format_field(@procid || Process.pid.to_s, 128),
                     message_id, sd, line]
         end
         if lines.size == 1

--- a/lib/syslogger/logger.rb
+++ b/lib/syslogger/logger.rb
@@ -16,6 +16,22 @@ module SysLogger
       @default_formatter = SysLogger::Formatter::RFC5424.new
     end
 
+    def appname=(appname)
+      @default_formatter.appname = appname
+    end
+
+    def appname
+      @default_formatter.appname
+    end
+
+    def procid=(procid)
+      @default_formatter.procid = procid
+    end
+
+    def procid
+      @default_formatter.appname
+    end
+
     def <<(msg)
       # Logger's version of this just dumps the input without formatting. there
       # is never a case where we don't want to format the content to the syslog

--- a/spec/syslogger/formatter/rfc5424_spec.rb
+++ b/spec/syslogger/formatter/rfc5424_spec.rb
@@ -3,9 +3,16 @@ require 'date'
 
 describe SysLogger::Formatter::RFC5424 do
   its(:msgid)    { is_expected.to eq "-" }
-  its(:procid)   { is_expected.to eq Process.pid.to_s }
-  its(:appname)  { is_expected.to eq "-" }
+  its(:procid)   { is_expected.to eq nil }
+  its(:appname)  { is_expected.to eq nil }
   its(:facility) { is_expected.to eq 23 }
+
+  let(:test_date) { DateTime.new(2019, 10, 31, 20, 8) }
+  let(:test_hostname) { "host1sf" }
+
+  before do
+    allow(Socket).to receive(:gethostname).and_return(test_hostname)
+  end
 
   describe "#call" do
     it "generates Format" do
@@ -27,6 +34,34 @@ describe SysLogger::Formatter::RFC5424 do
         counter2 = 0
       end
       expect(counter2).to be > counter1
+    end
+
+    context "nil appname" do
+      it "formats correctly" do
+        expect(Socket).to receive(:gethostname).and_return(test_hostname)
+        expect(subject).to receive(:gen_xgroup).and_return(74901736)
+        expect(subject.call(::Logger::INFO, test_date, "Prog", "Message")).to eq (
+          "<190>1 2019-10-31T20:08:00.000000+00:00 host1sf - #{Process.pid.to_s} Prog [meta x-group=\"74901736\" x-counter=\"1\"] Message\n"
+        )
+      end
+    end
+
+    context "custom appname" do
+      it "formats correctly" do
+        subject.appname = "short-appname"
+        expect(subject).to receive(:gen_xgroup).and_return(74901736)
+        expect(subject.call(::Logger::INFO, test_date, "Prog", "Message")).to eq (
+          "<190>1 2019-10-31T20:08:00.000000+00:00 host1sf short-appname #{Process.pid.to_s} Prog [meta x-group=\"74901736\" x-counter=\"1\"] Message\n"
+        )
+      end
+
+      it "truncates to 48 bytes" do
+        subject.appname = "this-is-a-very-long-appname-with-many-parts-in-it-for-sure-yep"
+        expect(subject).to receive(:gen_xgroup).and_return(74901736)
+        expect(subject.call(::Logger::INFO, test_date, "Prog", "Message")).to eq (
+          "<190>1 2019-10-31T20:08:00.000000+00:00 host1sf this-is-a-very-long-appname-with-many-parts-in-it #{Process.pid.to_s} Prog [meta x-group=\"74901736\" x-counter=\"1\"] Message\n"
+        )
+      end
     end
   end
 end

--- a/spec/syslogger_spec.rb
+++ b/spec/syslogger_spec.rb
@@ -1,9 +1,28 @@
 describe SysLogger do
-  let(:logger) { SysLogger.new(StringIO.new) }
+  let(:io)     { StringIO.new }
+  let(:logger) { SysLogger.new(io) }
 
   describe '#new' do
     it 'creates a Logger' do
       expect(logger).to be_a SysLogger::Logger
+    end
+  end
+
+  describe "#appname" do
+    it 'returns nil if appname is nil' do
+      expect(logger.appname).to be_nil
+      logger.info('test')
+      expect(io.string).to match(
+        /<190>1.* #{Socket.gethostname} - #{Process.pid} - \[meta.*/
+      )
+    end
+
+    it 'overrides the appname' do
+      logger.appname = 'an-appname'
+      logger.info('test')
+      expect(io.string).to match(
+        /<190>1.* #{Socket.gethostname} an-appname #{Process.pid} - \[meta.*/
+      )
     end
   end
 end


### PR DESCRIPTION
Also, fixes an obnoxious bug where the procid was set at formatter construction time in a really hard-to-override way, and thus would be wrong for programs that do pre-fork importing. Oops.